### PR TITLE
Added @types/unist to package.json dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   "contributors": [
     "Eugene Sharygin <eush77@gmail.com>",
     "Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)",
-    "Christian Murphy <christian.murphy.42@gmail.com>"
+    "Christian Murphy <christian.murphy.42@gmail.com>",
+    "Buzurgmehr Arjmandi <buzurg.arjmandi@gmail.com>"
   ],
   "files": [
     "index.js",
@@ -28,6 +29,7 @@
   ],
   "types": "types/index.d.ts",
   "dependencies": {
+    "@types/unist": "^2.0.3",
     "flatmap": "0.0.3",
     "unist-util-is": "^4.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   ],
   "types": "types/index.d.ts",
   "dependencies": {
+    "@types/unist": "^2.0.3",
     "flatmap": "0.0.3",
     "unist-util-is": "^4.0.0"
   },


### PR DESCRIPTION
This is a very minor change and adds the types provided by the `@types/unist` type declarations as a dependency for the basic `unist` types.  I made this change because the current library was causing issues with `tsc` doing a lib type check and finding that the import in "unist-util-filter/types/index.d.ts" of Node
i.e.
```typescript
import {node} from 'unist'
```
was breaking.  

Specifically this is the error I'm resolving: 
```

node_modules/unist-util-filter/types/index.d.ts:3:20 - error TS2307: Cannot find module 'unist'.

3 import {Node} from 'unist'
                     ~~~~~~~

node_modules/unist-util-is/index.d.ts:3:28 - error TS2307: Cannot find module 'unist'.

3 import {Node, Parent} from 'unist'
                             ~~~~~~~


Found 2 errors.
```

The only way to fix this was by adding in my project's tsconfig the setting `"skipLibCheck": true`  which is not really an acceptable solution.